### PR TITLE
Global composer option

### DIFF
--- a/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
+++ b/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
@@ -27,11 +27,19 @@ class ComposerAdapter{
         if (file_exists($pathToComposer)) {
             return $pathToComposer;
         }
-        $pathToComposer = exec("which composer.phar");
-        if (file_exists($pathToComposer)) {
-            return $pathToComposer;
-        }
-        if (file_exists("composer.phar")) {
+
+		$composerExecs = array('composer.phar', 'composer');
+		
+		foreach($composerExecs as $composerExec){
+			
+	        $pathToComposer = exec(sprintf("which %s", $composerExec));
+	
+	        if (file_exists($pathToComposer)) {
+	            return $pathToComposer;
+	        }
+		}
+		
+		if (file_exists("composer.phar")) {
             return "composer.phar";
         }
         return false;


### PR DESCRIPTION
This pull request takes into account that the user might install composer globally from these docs http://getcomposer.org/doc/00-intro.md, added option to have multiple composer executable names
