### PR TITLE
Update ComposerPathFinder.php

### DIFF
--- a/src/Mopa/Bridge/Composer/Util/ComposerPathFinder.php
+++ b/src/Mopa/Bridge/Composer/Util/ComposerPathFinder.php
@@ -35,8 +35,8 @@ class ComposerPathFinder
 
     protected function isPackageInstalled(PackageInterface $package)
     {
-        foreach ($this->composer->getRepositoryManager()
-                ->getLocalRepositories() as $repo) {
+        foreach (array($this->composer->getRepositoryManager()
+                ->getLocalRepository()) as $repo) {
             $installer = $this->composer->getInstallationManager()
                                 ->getInstaller($package->getType());
 


### PR DESCRIPTION
`getLocalRepositories` method for `Composer\RepositoryManager` is now marked as deprecated and throws an exception.
This change is an effective workaround.
