### PR TITLE
'which' command not available in windows

### DIFF
--- a/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
+++ b/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
@@ -35,10 +35,12 @@ class ComposerAdapter
             return '../composer.phar';
         }
         $composerExecs = array('composer.phar', 'composer');
-        
+
+        $isUnix = DIRECTORY_SEPARATOR == '/' ? true : false;
+
         foreach ($composerExecs as $composerExec) {
 
-            $pathToComposer = exec(sprintf("which %s", $composerExec));
+            $pathToComposer = exec(sprintf($isUnix ? "which %s" : "for %%i in (%s) do @echo.%%~\$PATH:i", $composerExec));
 
             if (file_exists($pathToComposer)) {
                 return $pathToComposer;


### PR DESCRIPTION
Maybe a minor one but this fixes my issue with 'which' command not found in windows for system wide installation
