### PR TITLE
PSR-4 Autoloading from composer.phar

### DIFF
--- a/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
+++ b/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
@@ -79,15 +79,7 @@ class ComposerAdapter
                 throw new \RuntimeException("Could not find composer.phar");
             }
             \Phar::loadPhar($pathToComposer, 'composer.phar');
-            $loader = new ClassLoader();
-            $namespaces = include("phar://composer.phar/vendor/composer/autoload_namespaces.php");
-            $loader->addPrefixes(array_merge(
-                array(
-                    'Composer' => "phar://composer.phar/src/"
-                ),
-                $namespaces
-            ));
-            $loader->register(true);
+            include("phar://composer.phar/vendor/autoload.php");
         }
     }
 


### PR DESCRIPTION
This is not a great patch, I don't know why it wasn't done this way originally but it does fix the issues with the PSR-4 dependencies as mentioned in https://github.com/phiamo/MopaComposerBridge/issues/15 and https://github.com/phiamo/MopaBootstrapBundle/issues/1112

I've only used this with the MopaBootstrap Commands so far so no idea what other knock on effects it might have.