### PR TITLE
Remove symfony/class-loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         }
     ],
     "require": {
-        "symfony/console": ">=2.0.0",
-        "symfony/class-loader": ">=2.0.0"
+        "symfony/console": ">=2.0.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
+++ b/src/Mopa/Bridge/Composer/Adapter/ComposerAdapter.php
@@ -5,7 +5,6 @@ use Composer;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\ClassLoader\ClassLoader;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 


### PR DESCRIPTION
`symfony/class-loader` is abandoned.

This package declares it as a dependency, and has an `use Symfony\Component\ClassLoader\ClassLoader;` statement in `ComposerAdapter.php`. However, it appears `ClassLoader` is not really used.

Thus this PR removes references to `symfony/class-loader`.